### PR TITLE
Update sid-audit.ps1

### DIFF
--- a/sid-audit.ps1
+++ b/sid-audit.ps1
@@ -82,11 +82,11 @@ $unidentifiedFSObjects = @() # objects with orphaned SIDs we can't identify
 #ForEach ($f in $fsObjects) {
 Get-ChildItem $fsFolder -Recurse -ErrorAction "Continue" | ForEach-Object {
     try {
-        $acl = Get-ACL $_.FullName
-        $aclAccess = $acl.Access
+   		$item = get-item -literalpath $_.FullName -ErrorAction "Continue"
+        $aclAccess = $item.GetAccessControl().Access
     } catch {
         Write-Host "Error: unable to read object ACL $($_)"
-        continue
+#        continue
     }
     $fsObjectCount += 1
     

--- a/sid-audit.ps1
+++ b/sid-audit.ps1
@@ -83,6 +83,7 @@ $unidentifiedFSObjects = @() # objects with orphaned SIDs we can't identify
 Get-ChildItem $fsFolder -Recurse -ErrorAction "Continue" | ForEach-Object {
     try {
    		$item = get-item -literalpath $_.FullName -ErrorAction "Continue"
+        $acl = Get-ACL $_.FullName
         $aclAccess = $item.GetAccessControl().Access
     } catch {
         Write-Host "Error: unable to read object ACL $($_)"


### PR DESCRIPTION
Script would error out if filename was too long, or if filename contains [ or ] character. using the -literalpath option to allow [ and ] in filenames, using -erroraction to actually not error out. removed continue from catch to stay in the foreach-object, else the script will exit after 1 error